### PR TITLE
Add checks for WorldEdit

### DIFF
--- a/buildinggame/src/main/java/com/gmail/stefvanschiedev/buildinggame/Main.java
+++ b/buildinggame/src/main/java/com/gmail/stefvanschiedev/buildinggame/Main.java
@@ -3,11 +3,12 @@ package com.gmail.stefvanschiedev.buildinggame;
 import co.aikar.commands.BukkitCommandManager;
 import co.aikar.commands.ConditionFailedException;
 import co.aikar.commands.InvalidCommandArgument;
-import com.gmail.stefvanschiedev.buildinggame.events.PerWorldInventoryCancel;
+import com.gmail.stefvanschiedev.buildinggame.events.softdependencies.PerWorldInventoryCancel;
 import com.gmail.stefvanschiedev.buildinggame.events.block.signs.*;
 import com.gmail.stefvanschiedev.buildinggame.events.entity.EntityOptionsMenu;
 import com.gmail.stefvanschiedev.buildinggame.events.player.*;
 import com.gmail.stefvanschiedev.buildinggame.events.player.signs.ClickSpectateSign;
+import com.gmail.stefvanschiedev.buildinggame.events.softdependencies.WorldEditBoundaryAssertion;
 import com.gmail.stefvanschiedev.buildinggame.managers.arenas.*;
 import com.gmail.stefvanschiedev.buildinggame.managers.commands.CommandManager;
 import com.gmail.stefvanschiedev.buildinggame.managers.softdependencies.LeaderHeadsStatistic;
@@ -15,7 +16,7 @@ import com.gmail.stefvanschiedev.buildinggame.managers.softdependencies.Placehol
 import com.gmail.stefvanschiedev.buildinggame.utils.arena.ArenaMode;
 import com.gmail.stefvanschiedev.buildinggame.utils.bungeecord.BungeeCordHandler;
 import com.gmail.stefvanschiedev.buildinggame.utils.stats.StatType;
-import com.google.common.collect.ImmutableList;
+import com.sk89q.worldedit.WorldEdit;
 import org.bstats.bukkit.MetricsLite;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.PluginManager;
@@ -289,6 +290,9 @@ public class Main extends JavaPlugin {
                     e.printStackTrace();
                 }
             }
+
+            if (pm.isPluginEnabled("WorldEdit"))
+                WorldEdit.getInstance().getEventBus().register(new WorldEditBoundaryAssertion());
 
 			pm.registerEvents(new ClickJoinSign(), this);
 			pm.registerEvents(new ClickLeaveSign(), this);

--- a/buildinggame/src/main/java/com/gmail/stefvanschiedev/buildinggame/events/softdependencies/PerWorldInventoryCancel.java
+++ b/buildinggame/src/main/java/com/gmail/stefvanschiedev/buildinggame/events/softdependencies/PerWorldInventoryCancel.java
@@ -1,4 +1,4 @@
-package com.gmail.stefvanschiedev.buildinggame.events;
+package com.gmail.stefvanschiedev.buildinggame.events.softdependencies;
 
 import com.gmail.stefvanschiedev.buildinggame.managers.arenas.ArenaManager;
 import me.gnat008.perworldinventory.events.InventoryLoadEvent;

--- a/buildinggame/src/main/java/com/gmail/stefvanschiedev/buildinggame/events/softdependencies/WorldEditBoundaryAssertion.java
+++ b/buildinggame/src/main/java/com/gmail/stefvanschiedev/buildinggame/events/softdependencies/WorldEditBoundaryAssertion.java
@@ -1,0 +1,63 @@
+package com.gmail.stefvanschiedev.buildinggame.events.softdependencies;
+
+import com.gmail.stefvanschiedev.buildinggame.managers.arenas.ArenaManager;
+import com.gmail.stefvanschiedev.buildinggame.utils.Region;
+import com.gmail.stefvanschiedev.buildinggame.utils.arena.Arena;
+import com.sk89q.worldedit.Vector;
+import com.sk89q.worldedit.WorldEditException;
+import com.sk89q.worldedit.blocks.BaseBlock;
+import com.sk89q.worldedit.bukkit.BukkitPlayer;
+import com.sk89q.worldedit.event.extent.EditSessionEvent;
+import com.sk89q.worldedit.event.platform.BlockInteractEvent;
+import com.sk89q.worldedit.extent.AbstractDelegateExtent;
+import com.sk89q.worldedit.extent.Extent;
+import com.sk89q.worldedit.extent.NullExtent;
+import com.sk89q.worldedit.util.eventbus.Subscribe;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+
+/**
+ * Implements necessary checks to assure that edits made by WorldEdit are in the boundary of the given plot. Is only
+ * active when WorldEdit is installed and enabled.
+ *
+ * @since 5.8.0
+ */
+public class WorldEditBoundaryAssertion {
+
+    /**
+     * Cancels any edits being made for blocks outside the plot the actor is (possibly) on.
+     *
+     * @param event the event fired when a session is being edited
+     * @since 5.8.0
+     */
+    @Subscribe
+    public void onEditSession(EditSessionEvent event) {
+        if (!event.getActor().isPlayer())
+            return;
+
+        Player player = Bukkit.getPlayer(event.getActor().getUniqueId());
+        Arena arena = ArenaManager.getInstance().getArena(player);
+
+        //don't do anything if the player isn't in an arena
+        if (arena == null)
+            return;
+
+        event.setExtent(new AbstractDelegateExtent(event.getExtent()) {
+            @Override
+            public boolean setBlock(Vector location, BaseBlock block) throws WorldEditException {
+                if (!arena.getPlot(player).getBoundary().isInside(new Location(
+                    Bukkit.getWorld(event.getWorld().getName()),
+                    location.getX(),
+                    location.getY(),
+                    location.getZ()
+                )))
+                    return false;
+
+                return super.setBlock(location, block);
+            }
+        });
+    }
+}


### PR DESCRIPTION
Any edits now made by WorldEdit are now ensured to be inside the boundary of the plot, not outside.