### PR TITLE
Fix duplicate holograms being saved

### DIFF
--- a/buildinggame/pom.xml
+++ b/buildinggame/pom.xml
@@ -137,6 +137,12 @@
             <artifactId>MVdWPlaceholderAPI</artifactId>
             <version>2.5.1-SNAPSHOT</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.spigotmc</groupId>
+                    <artifactId>spigot</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.gmail.filoghost.holographicdisplays</groupId>

--- a/buildinggame/src/main/java/com/gmail/stefvanschiedev/buildinggame/managers/files/SettingsManager.java
+++ b/buildinggame/src/main/java/com/gmail/stefvanschiedev/buildinggame/managers/files/SettingsManager.java
@@ -222,6 +222,8 @@ public final class SettingsManager {
 		}
 
 		if (hologramsFile.exists()) {
+		    TopStatHologram.clearAll();
+
             try {
                 var jsonReader = new Gson().newJsonReader(new InputStreamReader(new FileInputStream(hologramsFile)));
 

--- a/buildinggame/src/main/java/com/gmail/stefvanschiedev/buildinggame/utils/TopStatHologram.java
+++ b/buildinggame/src/main/java/com/gmail/stefvanschiedev/buildinggame/utils/TopStatHologram.java
@@ -190,6 +190,15 @@ public class TopStatHologram {
     }
 
     /**
+     * Clears all the {@link TopStatHologram}s currently registered.
+     *
+     * @since 6.5.1
+     */
+    public static void clearAll() {
+        HOLOGRAMS.clear();
+    }
+
+    /**
      * Gets a set of all currently registered holograms
      *
      * @return all holograms


### PR DESCRIPTION
Holograms were duplicated, because they were loaded twice. This no
longer happens, since any existing holograms will be removed prior to
loading the new file.