### PR TITLE
Add floor changers using Citizens

### DIFF
--- a/buildinggame/pom.xml
+++ b/buildinggame/pom.xml
@@ -53,6 +53,10 @@
             <id>mojang-repo</id>
             <url>https://libraries.minecraft.net/</url>
         </repository>
+        <repository>
+            <id>citizens</id>
+            <url>http://repo.citizensnpcs.co/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -154,6 +158,23 @@
             <artifactId>holographicdisplays-api</artifactId>
             <version>2.3.0</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.citizensnpcs</groupId>
+            <artifactId>citizens</artifactId>
+            <version>2.0.24-SNAPSHOT</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>text-api</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>text-adapter-bukkit</artifactId>
+            <version>3.0.3</version>
         </dependency>
     </dependencies>
 

--- a/buildinggame/src/main/java/com/gmail/stefvanschiedev/buildinggame/Main.java
+++ b/buildinggame/src/main/java/com/gmail/stefvanschiedev/buildinggame/Main.java
@@ -6,6 +6,7 @@ import co.aikar.commands.ConditionFailedException;
 import co.aikar.commands.InvalidCommandArgument;
 import com.github.stefvanschie.inventoryframework.Gui;
 import com.gmail.stefvanschiedev.buildinggame.events.block.BlockEdit;
+import com.gmail.stefvanschiedev.buildinggame.events.softdependencies.NPCCreate;
 import com.gmail.stefvanschiedev.buildinggame.events.softdependencies.PerWorldInventoryCancel;
 import com.gmail.stefvanschiedev.buildinggame.events.block.signs.*;
 import com.gmail.stefvanschiedev.buildinggame.events.entity.EntityOptionsMenu;
@@ -17,12 +18,15 @@ import com.gmail.stefvanschiedev.buildinggame.managers.commands.CommandManager;
 import com.gmail.stefvanschiedev.buildinggame.managers.softdependencies.PlaceholderAPIPlaceholders;
 import com.gmail.stefvanschiedev.buildinggame.timers.*;
 import com.gmail.stefvanschiedev.buildinggame.utils.Achievement;
+import com.gmail.stefvanschiedev.buildinggame.utils.NPCFloorChangeTrait;
 import com.gmail.stefvanschiedev.buildinggame.utils.PlaceholderSupplier;
 import com.gmail.stefvanschiedev.buildinggame.utils.TopStatHologram;
 import com.gmail.stefvanschiedev.buildinggame.utils.arena.ArenaMode;
 import com.gmail.stefvanschiedev.buildinggame.utils.bungeecord.BungeeCordHandler;
 import com.gmail.stefvanschiedev.buildinggame.utils.stats.StatType;
 import com.sk89q.worldedit.WorldEdit;
+import net.citizensnpcs.api.CitizensAPI;
+import net.citizensnpcs.api.trait.TraitInfo;
 import org.bstats.bukkit.MetricsLite;
 import org.bukkit.Bukkit;
 import org.bukkit.DyeColor;
@@ -329,6 +333,13 @@ public class Main extends JavaPlugin {
 
             if (pm.isPluginEnabled("WorldEdit"))
                 WorldEdit.getInstance().getEventBus().register(new WorldEditBoundaryAssertion());
+
+            if (pm.isPluginEnabled("Citizens")) {
+                pm.registerEvents(new NPCCreate(), this);
+
+                TraitInfo traitInfo = TraitInfo.create(NPCFloorChangeTrait.class).withName("buildinggame:floorchange");
+                CitizensAPI.getTraitFactory().registerTrait(traitInfo);
+            }
 
 			pm.registerEvents(new ClickJoinSign(), this);
 			pm.registerEvents(new ClickLeaveSign(), this);

--- a/buildinggame/src/main/java/com/gmail/stefvanschiedev/buildinggame/events/softdependencies/NPCCreate.java
+++ b/buildinggame/src/main/java/com/gmail/stefvanschiedev/buildinggame/events/softdependencies/NPCCreate.java
@@ -1,0 +1,94 @@
+package com.gmail.stefvanschiedev.buildinggame.events.softdependencies;
+
+import com.gmail.stefvanschiedev.buildinggame.managers.arenas.ArenaManager;
+import com.gmail.stefvanschiedev.buildinggame.managers.messages.MessageManager;
+import com.gmail.stefvanschiedev.buildinggame.utils.CommandUtil;
+import com.gmail.stefvanschiedev.buildinggame.utils.NPCFloorChangeTrait;
+import com.gmail.stefvanschiedev.buildinggame.utils.plot.Plot;
+import net.citizensnpcs.api.event.NPCSpawnEvent;
+import net.citizensnpcs.api.event.PlayerCreateNPCEvent;
+import net.citizensnpcs.api.npc.NPC;
+import net.kyori.text.TextComponent;
+import net.kyori.text.adapter.bukkit.TextAdapter;
+import net.kyori.text.event.ClickEvent;
+import net.kyori.text.format.TextColor;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+import java.util.WeakHashMap;
+
+/**
+ * Listens to NPC creation to see if they are inside a plot and automatically asks you if you want to make it a floor
+ * changer.
+ *
+ * @since 7.1.0
+ */
+public class NPCCreate implements Listener {
+
+    /**
+     * A map of {@link NPC}s and their spawners which have been created, but not yet spawned
+     */
+    private final Map<NPC, Player> toBeSpawned = new WeakHashMap<>();
+
+    /**
+     * Called when a {@link NPC} is created
+     *
+     * @param event the event fired when an {@link NPC} is created
+     * @since 7.1.0
+     */
+    @EventHandler
+    private void onNPCCreate(@NotNull PlayerCreateNPCEvent event) {
+        toBeSpawned.put(event.getNPC(), event.getCreator());
+    }
+
+    /**
+     * Called when a {@link NPC} is spawned
+     *
+     * @param event the event fired when an {@link NPC} is spawned
+     * @since 7.1.0
+     */
+    @EventHandler
+    private void onNPCSpawn(@NotNull NPCSpawnEvent event) {
+        toBeSpawned.entrySet().stream()
+            .filter(entry -> event.getNPC().equals(entry.getKey()))
+            .findAny()
+            .ifPresent(entry -> {
+                NPC npc = entry.getKey();
+                toBeSpawned.remove(npc);
+
+                if (ArenaManager.getInstance().getArenas().stream()
+                    .flatMap(arena -> arena.getPlots().stream())
+                    .map(Plot::getBoundary)
+                    .anyMatch(boundary -> boundary.isInside(event.getLocation()))) {
+                    Player player = entry.getValue();
+
+                    TextComponent textComponent = TextComponent.of(
+                        "You have spawned an NPC inside a plot, would you like to allow players to use this NPC to change their plot's floor? Please click "
+                    )
+                        .color(TextColor.GOLD)
+                        .append(TextComponent.of("here")
+                            .color(TextColor.AQUA)
+                            .clickEvent(ClickEvent.runCommand('/' + CommandUtil.createTempCommand(sender -> {
+                                if (!sender.equals(player)) {
+                                    return;
+                                }
+
+                                npc.addTrait(new NPCFloorChangeTrait());
+
+                                MessageManager.getInstance().send(player, ChatColor.GREEN +
+                                    "This NPC now allows players to change their plot's floor");
+                            }))))
+                        .append(TextComponent.of(
+                            " if so, otherwise ignore this message. This will expire in 60 seconds."
+                        )
+                            .color(TextColor.GOLD));
+
+                    TextAdapter.sendComponent(player, textComponent);
+                }
+            });
+    }
+}

--- a/buildinggame/src/main/java/com/gmail/stefvanschiedev/buildinggame/utils/CommandUtil.java
+++ b/buildinggame/src/main/java/com/gmail/stefvanschiedev/buildinggame/utils/CommandUtil.java
@@ -1,8 +1,20 @@
 package com.gmail.stefvanschiedev.buildinggame.utils;
 
+import com.gmail.stefvanschiedev.buildinggame.Main;
 import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandMap;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.SimpleCommandMap;
+import org.bukkit.plugin.SimplePluginManager;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Consumer;
 
 /**
  * A class with utility methods for handling commands
@@ -10,6 +22,11 @@ import org.jetbrains.annotations.NotNull;
  * @since 7.0.1
  */
 public final class CommandUtil {
+
+    /**
+     * The command map
+     */
+    private static final CommandMap COMMAND_MAP = getCommandMap();
 
     /**
      * Private constructor to avoid instantiating this utility class.
@@ -20,9 +37,58 @@ public final class CommandUtil {
     private CommandUtil() {}
 
     /**
+     * Creates a temporary command. When the command is executed the {@code onCalled} {@link Consumer} will be called
+     * with the {@link CommandSender} who executed the command. This command will automatically be destroyed when the
+     * command has been ran once, or after 60 seconds.
+     *
+     * @param onCalled when the command is being executed, this will be called.
+     * @return the name of the command
+     * @since 7.1.0
+     */
+    public static String createTempCommand(Consumer<CommandSender> onCalled) {
+        UUID uuid = UUID.randomUUID();
+
+        Command command = new Command(uuid.toString()) {
+            @Override
+            public boolean execute(@NotNull CommandSender commandSender, @NotNull String label,
+                                   @NotNull String[] args) {
+                onCalled.accept(commandSender);
+
+                try {
+                    Field field = SimpleCommandMap.class.getDeclaredField("knownCommands");
+                    field.setAccessible(true);
+                    //noinspection unchecked: this is safe, because the field is a HashMap<String, Command>
+                    ((Map<String, Command>) field.get(COMMAND_MAP)).remove(uuid.toString());
+                } catch (NoSuchFieldException | IllegalAccessException e) {
+                    e.printStackTrace();
+                }
+
+                unregister(COMMAND_MAP);
+
+                return true;
+            }
+        };
+
+        Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
+            try {
+                Field field = SimpleCommandMap.class.getDeclaredField("knownCommands");
+                field.setAccessible(true);
+                //noinspection unchecked: this is safe, because the field is a HashMap<String, Command>
+                ((Map<String, Command>) field.get(COMMAND_MAP)).remove(uuid.toString());
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                e.printStackTrace();
+            }
+        }, 1200);
+
+        COMMAND_MAP.register(uuid.toString(), command);
+
+        return uuid.toString();
+    }
+
+    /**
      * Dispatches the specified command, with respect for any optionally specified target.
      *
-     * @param command the command to disptach
+     * @param command the command to dispatch
      * @since 7.0.1
      */
     public static void dispatch(@NotNull String command) {
@@ -32,6 +98,26 @@ public final class CommandUtil {
             Target.parse(targetText).execute(command.substring(targetText.length() + 1));
         } else {
             Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command);
+        }
+    }
+
+    /**
+     * Gets the command map currently in use
+     *
+     * @return the command map
+     * @since 7.1.0
+     */
+    @Nullable
+    @Contract(pure = true)
+    private static CommandMap getCommandMap() {
+        try {
+            Field field = SimplePluginManager.class.getDeclaredField("commandMap");
+            field.setAccessible(true);
+            return (CommandMap) field.get(Bukkit.getPluginManager());
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            e.printStackTrace();
+
+            return null;
         }
     }
 }

--- a/buildinggame/src/main/java/com/gmail/stefvanschiedev/buildinggame/utils/NPCFloorChangeTrait.java
+++ b/buildinggame/src/main/java/com/gmail/stefvanschiedev/buildinggame/utils/NPCFloorChangeTrait.java
@@ -1,0 +1,141 @@
+package com.gmail.stefvanschiedev.buildinggame.utils;
+
+import com.gmail.stefvanschiedev.buildinggame.managers.arenas.ArenaManager;
+import com.gmail.stefvanschiedev.buildinggame.managers.files.SettingsManager;
+import com.gmail.stefvanschiedev.buildinggame.managers.messages.MessageManager;
+import net.citizensnpcs.api.event.NPCClickEvent;
+import net.citizensnpcs.api.event.NPCLeftClickEvent;
+import net.citizensnpcs.api.event.NPCRightClickEvent;
+import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.api.trait.Trait;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.event.EventHandler;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A trait for a citizens NPS that enables this NPC to open the floor change menu, or apply the block as in the player's
+ * hand as the floor.
+ *
+ * @since 7.1.0
+ */
+public class NPCFloorChangeTrait extends Trait {
+
+    /**
+     * Creates a new instance of this trait.
+     *
+     * @since 7.1.0
+     */
+    public NPCFloorChangeTrait() {
+        super("buildinggame:floorchange");
+    }
+
+    /**
+     * Handles a player clicking on this NPC and applying the block as floor, or opening the floor menu.
+     *
+     * @param event the event that got fired when an {@link NPC} is clicked
+     * @since 7.1.0
+     */
+    private void handleClick(@NotNull NPCClickEvent event) {
+        YamlConfiguration config = SettingsManager.getInstance().getConfig();
+        YamlConfiguration messages = SettingsManager.getInstance().getMessages();
+
+        if (!event.getNPC().equals(getNPC())) {
+            return;
+        }
+
+        var player = event.getClicker();
+        var arena = ArenaManager.getInstance().getArena(player);
+
+        if (arena == null) {
+            return;
+        }
+
+        var plot = arena.getPlot(player);
+        var floorMenu = plot.getBuildMenu().getFloorMenu();
+        long floorChange = floorMenu.getLastFloorChange();
+
+        int cooldown = (int) config.getDouble("gui.floor.cooldown") * 1000;
+
+        if (cooldown > 0 && System.currentTimeMillis() - floorChange < cooldown) {
+            MessageManager.getInstance().send(player, ChatColor.YELLOW + "You have to wait " +
+                (((cooldown - System.currentTimeMillis()) + floorChange) / 1000.0) +
+                " seconds before you can change the floor again");
+            event.setCancelled(true);
+            return;
+        }
+
+        Material materialInHand = player.getInventory().getItemInMainHand().getType();
+
+        if (materialInHand == Material.AIR) {
+            floorMenu.show(player);
+            floorMenu.setLastFloorChange(System.currentTimeMillis());
+            event.setCancelled(true);
+            return;
+        }
+
+        if (config.getStringList("blocks.blocked").stream().anyMatch(material ->
+            Material.matchMaterial(material) == materialInHand)) {
+            MessageManager.getInstance().send(player, messages.getStringList("plots.floor.blocked"));
+
+            event.setCancelled(true);
+            return;
+        }
+
+        if (materialInHand == Material.WATER_BUCKET) {
+            plot.getFloor().getAllBlocks().forEach(block -> block.setType(Material.WATER));
+
+            floorMenu.setLastFloorChange(System.currentTimeMillis());
+
+            event.setCancelled(true);
+            return;
+        }
+
+        if (materialInHand == Material.LAVA_BUCKET) {
+            plot.getFloor().getAllBlocks().forEach(block -> block.setType(Material.LAVA));
+
+            floorMenu.setLastFloorChange(System.currentTimeMillis());
+
+            event.setCancelled(true);
+            return;
+        }
+
+        if (!materialInHand.isBlock()) {
+            MessageManager.getInstance().send(player, messages.getStringList("plots.floor.incorrect"));
+
+            event.setCancelled(true);
+            return;
+        }
+
+        plot.getFloor().getAllBlocks().stream()
+            .filter(block -> block.getType() != materialInHand)
+            .forEach(block -> block.setType(materialInHand));
+
+        floorMenu.setLastFloorChange(System.currentTimeMillis());
+
+        event.setCancelled(true);
+    }
+
+    /**
+     * Handles players left clicking on NPCs.
+     *
+     * @param event the event called when a player left clicked on a NPC
+     * @since 7.1.0
+     */
+    @EventHandler
+    public void onLeftClick(@NotNull NPCLeftClickEvent event) {
+        handleClick(event);
+    }
+
+    /**
+     * Handles players right clicking on NPCs.
+     *
+     * @param event the event called when a player right clicked on a NPC
+     * @since 7.1.0
+     */
+    @EventHandler
+    public void onRightClick(@NotNull NPCRightClickEvent event) {
+        handleClick(event);
+    }
+}

--- a/buildinggame/src/main/java/com/gmail/stefvanschiedev/buildinggame/utils/guis/buildmenu/FloorMenu.java
+++ b/buildinggame/src/main/java/com/gmail/stefvanschiedev/buildinggame/utils/guis/buildmenu/FloorMenu.java
@@ -25,12 +25,17 @@ import java.util.Locale;
  *
  * @since 4.0.0
  */
-class FloorMenu extends Gui {
+public class FloorMenu extends Gui {
 
     /**
      * YAML Configuration for the messages.yml
      */
 	private static final YamlConfiguration MESSAGES = SettingsManager.getInstance().getMessages();
+
+    /**
+     * The last time the floor was changed (according to System.currentMillis())
+     */
+    private long floorChange;
 
 	/**
      * An item stack for going to the previous page
@@ -257,6 +262,27 @@ class FloorMenu extends Gui {
 		
 		return blocks;
 	}
+
+    /**
+     * Sets the last time the floor was changed specified as milliseconds elapsed since the UNIX epoch.
+     *
+     * @param lastFloorChange the last time the floor was changed
+     * @since 7.1.0
+     */
+	public void setLastFloorChange(long lastFloorChange) {
+	    this.floorChange = lastFloorChange;
+    }
+
+    /**
+     * Gets the last time the floor was changed as milliseconds elapsed since the UNIX epoch.
+     *
+     * @return the time the floor was last changed
+     * @since 7.1.0
+     */
+	@Contract(pure = true)
+	public long getLastFloorChange() {
+	    return floorChange;
+    }
 	
 	static {
 		PREVIOUS_PAGE = new ItemStack(Material.SUGAR_CANE);

--- a/buildinggame/src/main/resources/plugin.yml
+++ b/buildinggame/src/main/resources/plugin.yml
@@ -2,6 +2,6 @@ main: com.gmail.stefvanschiedev.buildinggame.Main
 version: 7.0.0
 name: BuildingGame
 author: stefvanschie
-softdepend: [Vault, LeaderHeads, PerWorldInventory, PlaceholderAPI, WorldEdit, MVdWPlaceholderAPI, HolographicDisplays]
+softdepend: [Vault, PerWorldInventory, PlaceholderAPI, WorldEdit, MVdWPlaceholderAPI, HolographicDisplays, Citizens]
 
 api-version: 1.13


### PR DESCRIPTION
These can be placed and allow users to edit the floor by clicking on
them. Clicking with an item in your hand will use that item as the
floor; clicking with nothing in your hand will open a menu with blocks
to choose from.

When an NPC is placed inside a plot, the user that did so will
automatically be asked if they want this NPC be capable of changing the
floor. This functionality can be enabled at a later point for any NPC by
adding the buildinggame:floorchange trait to the NPC by using Citizens
commands.